### PR TITLE
fix: use computed value for giscus theme

### DIFF
--- a/docs/.vitepress/theme/components/Comment.vue
+++ b/docs/.vitepress/theme/components/Comment.vue
@@ -2,9 +2,12 @@
 import Giscus from '@giscus/vue'
 import DefaultTheme from 'vitepress/theme'
 import { useData } from 'vitepress'
+import { computed } from 'vue'
 
 const { isDark } = useData()
 const { Layout } = DefaultTheme
+
+const theme = computed(() => isDark.value ? 'transparent_dark' : 'light_tritanopia')
 </script>
 
 <template>
@@ -13,7 +16,7 @@ const { Layout } = DefaultTheme
       <div id="giscus">
         <Giscus id="comments" repo="mancuoj/csdiy" repoId="R_kgDOIcH4QA" category="Announcements"
           categoryId="DIC_kwDOIcH4QM4CSljH" mapping="pathname" strict="1" reactionsEnabled="1" emitMetadata="0"
-          inputPosition="top" lang="zh-CN" loading="lazy" :theme="[isDark ? 'transparent_dark' : 'light_tritanopia']" />
+          inputPosition="top" lang="zh-CN" loading="lazy" :theme="theme" />
       </div>
     </template>
   </Layout>


### PR DESCRIPTION
You need to use `computed` as otherwise the theme will only be calculated on initial render.

https://user-images.githubusercontent.com/6379424/208313086-0f0d9756-d96b-4d87-9282-4850f5c2d401.mov

